### PR TITLE
[BUG] Cant create new Customer in Postgres via REST

### DIFF
--- a/boot/src/main/java/mini/auth/boot/entities/Customer.java
+++ b/boot/src/main/java/mini/auth/boot/entities/Customer.java
@@ -10,7 +10,7 @@ import javax.persistence.Id;
 public class Customer {
 
     @Id
-    @GeneratedValue(strategy=GenerationType.AUTO)
+    @GeneratedValue(strategy=GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "username", unique = true)

--- a/boot/src/main/resources/db/migration/postgresql/V1.0.0.2__alter_customer_pk_to_serial.sql
+++ b/boot/src/main/resources/db/migration/postgresql/V1.0.0.2__alter_customer_pk_to_serial.sql
@@ -1,0 +1,2 @@
+create sequence seq_customer_id start with 3 owned by customer.id;
+alter table customer alter column id set default nextval('seq_customer_id');


### PR DESCRIPTION
Root causes
1. hibernate_sequence does not exist:
```
org.postgresql.util.PSQLException: ERROR: relation "hibernate_sequence" does not exist
```

2. column id in Customer table is using fixed integer number and does not automatically generate new sequence number when adding new row to table, thus null is inserted and violate the primary key constraint.